### PR TITLE
fix deployment job download artifact failure

### DIFF
--- a/pipelines/api-pipelines.yml
+++ b/pipelines/api-pipelines.yml
@@ -8,6 +8,8 @@ trigger:
     include:
       - api/*
       - pipelines/api-pipelines.yml
+      - pipelines/templates/api-build.yml
+      - pipelines/templates/api-deploy-environment.yml
 
 pr:
   autoCancel: true
@@ -18,6 +20,8 @@ pr:
     include:
       - api/*
       - pipelines/api-pipelines.yml
+      - pipelines/templates/api-build.yml
+      - pipelines/templates/api-deploy-environment.yml
 
 pool:
   vmImage: "ubuntu-latest"

--- a/pipelines/deploy-infrastructure.yml
+++ b/pipelines/deploy-infrastructure.yml
@@ -8,6 +8,8 @@ trigger:
     include:
       - deployment/*
       - pipelines/deploy-infrastructure.yml
+      - pipelines/templates/iac-deploy-environment.yml
+
 
 pr: none
 

--- a/pipelines/frontend-pipeline.yml
+++ b/pipelines/frontend-pipeline.yml
@@ -8,6 +8,8 @@ trigger:
     include:
       - frontend/*
       - pipelines/frontend-pipeline.yml
+      - pipelines/templates/frontend-build.yml
+      - pipelines/templates/frontend-deploy-environment.yml
 
 pr:
   autoCancel: true
@@ -18,6 +20,8 @@ pr:
     include:
       - frontend/*
       - pipelines/frontend-pipeline.yml
+      - pipelines/templates/frontend-build.yml
+      - pipelines/templates/frontend-deploy-environment.yml
 
 variables:
   - group: prodoh-urlist-common

--- a/pipelines/templates/api-deploy-environment.yml
+++ b/pipelines/templates/api-deploy-environment.yml
@@ -8,11 +8,12 @@ parameters:
 jobs:
   - deployment: 
     environment: ${{ parameters.environment }}
-    displayName: Deploy API Backend
+    displayName: Validate ${{ parameters.environment }} Approval
     strategy:
       runOnce:
         deploy:
           steps:
+            - download: none  # skip the default Download Artifacts part of the task
             - bash: echo "Deploying ${{ parameters.environment }} environment"
               displayName: Check for Approval
   - job: setup

--- a/pipelines/templates/frontend-deploy-environment.yml
+++ b/pipelines/templates/frontend-deploy-environment.yml
@@ -8,11 +8,12 @@ parameters:
 jobs:
   - deployment: 
     environment: ${{ parameters.environment }}
-    displayName: Deploy Frontend
+    displayName: Validate ${{ parameters.environment }} Approval
     strategy:
       runOnce:
         deploy:
           steps:
+            - download: none  # skip the default Download Artifacts part of the task
             - bash: echo "Deploying ${{ parameters.environment }} environment"
               displayName: Check for Approval
   - job: BuildArtifacts


### PR DESCRIPTION
1. skip the default "Download Artifact" step of the deployment job as
we're already doing that in a later part.

1. update pipeline trigger file pattern