### PR TITLE
separate combo pipelines into build & deploy pipelines

### DIFF
--- a/pipelines/api-build.yml
+++ b/pipelines/api-build.yml
@@ -1,0 +1,24 @@
+name: api-build
+
+pr:
+  autoCancel: true
+  branches:
+    include:
+      - master
+  paths:
+    include:
+      - api/*
+      - pipelines/api-build.yml
+      - pipelines/templates/api-build.yml
+
+pool:
+  vmImage: "ubuntu-latest"
+
+variables:
+  - group: prodoh-urlist-common
+
+stages:
+  - stage: BuildAndValidate
+    displayName: Build & Validate
+    jobs:
+      - template: templates/api-build.yml

--- a/pipelines/api-build.yml
+++ b/pipelines/api-build.yml
@@ -1,16 +1,5 @@
 name: api-build
 
-pr:
-  autoCancel: true
-  branches:
-    include:
-      - master
-  paths:
-    include:
-      - api/*
-      - pipelines/api-build.yml
-      - pipelines/templates/api-build.yml
-
 pool:
   vmImage: "ubuntu-latest"
 

--- a/pipelines/api-deploy.yml
+++ b/pipelines/api-deploy.yml
@@ -1,4 +1,4 @@
-name: api-pipeline
+name: api-deploy
 
 trigger:
   branches:
@@ -7,21 +7,13 @@ trigger:
   paths:
     include:
       - api/*
-      - pipelines/api-pipelines.yml
+      - pipelines/api-build.yml
+      - pipelines/api-deploy.yml
       - pipelines/templates/api-build.yml
       - pipelines/templates/api-deploy-environment.yml
+      - pipelines/templates/deployment-gate.yml
 
-pr:
-  autoCancel: true
-  branches:
-    include:
-      - master
-  paths:
-    include:
-      - api/*
-      - pipelines/api-pipelines.yml
-      - pipelines/templates/api-build.yml
-      - pipelines/templates/api-deploy-environment.yml
+pr: none
 
 pool:
   vmImage: "ubuntu-latest"
@@ -38,7 +30,6 @@ stages:
   - stage: Development
     displayName: Development
     dependsOn: BuildAndValidate
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     variables:
       - group: prodoh-urlist-dev
     jobs:

--- a/pipelines/deploy-infrastructure.yml
+++ b/pipelines/deploy-infrastructure.yml
@@ -9,7 +9,7 @@ trigger:
       - deployment/*
       - pipelines/deploy-infrastructure.yml
       - pipelines/templates/iac-deploy-environment.yml
-
+      - pipelines/templates/deployment-gate.yml
 
 pr: none
 

--- a/pipelines/frontend-build.yml
+++ b/pipelines/frontend-build.yml
@@ -1,16 +1,5 @@
 name: $(Date:yyyyMMdd)$(Rev:.r) # build numbering format
 
-# only works for GitHub
-pr:
-  autoCancel: true
-  branches:
-    include:
-      - master
-  paths:
-    include:
-      - frontend/*
-      - pipelines/frontend-build.yml
-
 variables:
   - group: prodoh-urlist-common
   - group: prodoh-urlist-dev

--- a/pipelines/frontend-build.yml
+++ b/pipelines/frontend-build.yml
@@ -1,0 +1,33 @@
+name: $(Date:yyyyMMdd)$(Rev:.r) # build numbering format
+
+# only works for GitHub
+pr:
+  autoCancel: true
+  branches:
+    include:
+      - master
+  paths:
+    include:
+      - frontend/*
+      - pipelines/frontend-build.yml
+
+variables:
+  - group: prodoh-urlist-common
+  - group: prodoh-urlist-dev
+
+pool:
+  vmImage: "ubuntu-latest"
+
+steps:
+  - task: Npm@1
+    displayName: Install Dependencies
+    inputs:
+      workingDir: "./frontend"
+      command: "install"
+
+  - task: Bash@3
+    displayName: Build frontend
+    inputs:
+      workingDirectory: "./frontend"
+      targetType: "inline"
+      script: "npm run build"

--- a/pipelines/frontend-deploy.yml
+++ b/pipelines/frontend-deploy.yml
@@ -1,4 +1,4 @@
-name: frontend-pipeline
+name: frontend-deploy
 
 trigger:
   branches:
@@ -7,21 +7,13 @@ trigger:
   paths:
     include:
       - frontend/*
-      - pipelines/frontend-pipeline.yml
+      - pipelines/frontend-build.yml
+      - pipelines/frontend-deploy.yml
       - pipelines/templates/frontend-build.yml
       - pipelines/templates/frontend-deploy-environment.yml
+      - pipelines/templates/deployment-gate.yml
 
-pr:
-  autoCancel: true
-  branches:
-    include:
-      - master
-  paths:
-    include:
-      - frontend/*
-      - pipelines/frontend-pipeline.yml
-      - pipelines/templates/frontend-build.yml
-      - pipelines/templates/frontend-deploy-environment.yml
+pr: none
 
 variables:
   - group: prodoh-urlist-common
@@ -32,7 +24,6 @@ pool:
 stages:
   - stage: Development
     displayName: Development
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     variables:
       - group: prodoh-urlist-dev
     jobs:

--- a/pipelines/templates/api-build.yml
+++ b/pipelines/templates/api-build.yml
@@ -16,6 +16,7 @@ jobs:
 
       - task: DotNetCoreCLI@2
         displayName: Run Unit Tests
+        condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           command: test
           projects: '**/LinkyLink.Tests/*.csproj'
@@ -26,16 +27,19 @@ jobs:
           dotnet tool install -g dotnet-reportgenerator-globaltool
           reportgenerator -reports:$(Agent.TempDirectory)/**/coverage.cobertura.xml -targetdir:$(Build.SourcesDirectory)/coverlet/reports -reporttypes:"Cobertura"
         displayName: Create Code coverage report
+        condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
 
       - task: PublishCodeCoverageResults@1
         displayName: Publish Code Coverage
+        condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           codeCoverageTool: Cobertura
           summaryFileLocation: $(Build.SourcesDirectory)/coverlet/reports/Cobertura.xml 
-          failIfCoverageEmpty: true 
+          failIfCoverageEmpty: true
 
       - task: BuildQualityChecks@6
         displayName: Validate Code Coverage Quality
+        condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:
           checkCoverage: true
           coverageFailOption: 'fixed'
@@ -44,6 +48,7 @@ jobs:
 
       - task: DotNetCoreCLI@2
         displayName: Package Build Artifacts
+        condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           command: publish
           arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)'

--- a/pipelines/templates/api-deploy-environment.yml
+++ b/pipelines/templates/api-deploy-environment.yml
@@ -6,16 +6,10 @@ parameters:
   regions: []
 
 jobs:
-  - deployment: 
-    environment: ${{ parameters.environment }}
-    displayName: Validate ${{ parameters.environment }} Approval
-    strategy:
-      runOnce:
-        deploy:
-          steps:
-            - download: none  # skip the default Download Artifacts part of the task
-            - bash: echo "Deploying ${{ parameters.environment }} environment"
-              displayName: Check for Approval
+  - template: deployment-gate.yml
+    parameters:
+      environment: ${{ parameters.environment }}
+      
   - job: setup
     displayName: Initialize
     variables:

--- a/pipelines/templates/deployment-gate.yml
+++ b/pipelines/templates/deployment-gate.yml
@@ -1,0 +1,14 @@
+parameters:
+  environment: "" 
+
+jobs:
+  - deployment: 
+    environment: ${{ parameters.environment }}
+    displayName: Validate ${{ parameters.environment }} Approval
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+            - download: none  # skip the default Download Artifacts part of the task
+            - bash: echo "Deploying ${{ parameters.environment }} environment"
+              displayName: Check for Approval

--- a/pipelines/templates/frontend-deploy-environment.yml
+++ b/pipelines/templates/frontend-deploy-environment.yml
@@ -6,16 +6,10 @@ parameters:
   regions: []
 
 jobs:
-  - deployment: 
-    environment: ${{ parameters.environment }}
-    displayName: Validate ${{ parameters.environment }} Approval
-    strategy:
-      runOnce:
-        deploy:
-          steps:
-            - download: none  # skip the default Download Artifacts part of the task
-            - bash: echo "Deploying ${{ parameters.environment }} environment"
-              displayName: Check for Approval
+  - template: deployment-gate.yml
+    parameters:
+      environment: ${{ parameters.environment }}
+
   - job: BuildArtifacts
     displayName: Build environment artifacts
     steps:

--- a/pipelines/templates/iac-deploy-environment.yml
+++ b/pipelines/templates/iac-deploy-environment.yml
@@ -6,15 +6,10 @@ parameters:
   regions: []
 
 jobs:
-  - deployment: 
-    environment: ${{ parameters.environment }}
-    displayName: Deploy Infrastructure
-    strategy:
-      runOnce:
-        deploy:
-          steps:
-            - bash: echo "Deploying ${{ parameters.environment }} environment"
-              displayName: Check for Approval
+  - template: deployment-gate.yml
+    parameters:
+      environment: ${{ parameters.environment }}
+      
   - job: setup
     displayName: Initialize
     variables:


### PR DESCRIPTION
1. existing pipelines contain both build & deploy components, this change separate them into individual pipelines

Benefits:
1) a more accurate usage of AzDO built-in deploy success metrics (mix of build&deploy means we were incorrectly counting failed PR builds)
2) easier to find deploys without the mix of pr builds
3) showing accurate pipeline badge status in markdown