### PR TITLE
fix: Updates version number for BuildQualityGates

### DIFF
--- a/pipelines/templates/api-build.yml
+++ b/pipelines/templates/api-build.yml
@@ -45,7 +45,7 @@ jobs:
           summaryFileLocation: $(Build.SourcesDirectory)/coverlet/reports/Cobertura.xml
           failIfCoverageEmpty: true
 
-      - task: BuildQualityChecks@6
+      - task: BuildQualityChecks@7
         displayName: Validate Code Coverage Quality
         condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
         inputs:


### PR DESCRIPTION
Current version v6 is deprecated and we need to update to v7 for the existing pipelines to pass.